### PR TITLE
update ng2-drag-drop

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -286,7 +286,7 @@
 
  - [ng2-dragula](https://github.com/valor-software/ng2-dragula) - Simple drag and drop with dragula.
  - [ng2-dnd](https://github.com/akserg/ng2-dnd) - Angular 2 Drag-and-Drop without dependencies.
- - [ng-drag-drop](https://github.com/ObaidUrRehman/ng-drag-drop) - Angular 2/4 Drag & Drop based on HTML5 with no external dependencies.
+ - [ng-drag-drop](https://github.com/ObaidUrRehman/ng-drag-drop) - Angular 4 Drag & Drop based on HTML5 with no external dependencies.
 
 ###### Sortable List
 

--- a/readme.md
+++ b/readme.md
@@ -286,7 +286,7 @@
 
  - [ng2-dragula](https://github.com/valor-software/ng2-dragula) - Simple drag and drop with dragula.
  - [ng2-dnd](https://github.com/akserg/ng2-dnd) - Angular 2 Drag-and-Drop without dependencies.
- - [ng2-drag-drop](https://github.com/ObaidUrRehman/ng2-drag-drop) - Angular 2 Drag & Drop based on HTML5 with no external dependencies.
+ - [ng-drag-drop](https://github.com/ObaidUrRehman/ng-drag-drop) - Angular 2/4 Drag & Drop based on HTML5 with no external dependencies.
 
 ###### Sortable List
 


### PR DESCRIPTION
Library name changed from ng2-drag-drop to ng-drag-drop now this library also supports for angular 4.

* Don't create a pull request to add a library, instead use [devarchy.com/angular](https://devarchy.com/angular).
* Only create a pull request to change the categorization.
* Open an issue if you are not sure how to change the categorization to fit a library you want to add.
