### PR TITLE
docs(lib): adds casl-angular

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -64,6 +64,7 @@
     - [Animations](#animations)
     - [API](#api)
     - [Authentication](#authentication)
+    - [Authorization](#authorization)
     - [Event Handling](#event-handling)
     - [Scroll](#scroll)
     - [Responsive Design](#responsive-design)
@@ -475,6 +476,10 @@
  - [angular-oauth2-oidc](https://github.com/manfredsteyer/angular-oauth2-oidc) - Support for OAuth 2 and OpenId Connect (OIDC) in Angular.
  - [angular-oauth2](https://github.com/oauthjs/angular-oauth2) - AngularJS OAuth2.
  - [@ngx-auth/core](https://github.com/fulls1z3/ngx-auth) - Authentication utility for Angular.
+
+###### Authorization
+
+- [casl-angular](https://github.com/stalniy/casl/tree/master/packages/casl-angular) - Permissions management module which integrates CASL with Angular2+
 
 ###### Event Handling
 


### PR DESCRIPTION
I added a library which allows to integrate [CASL](https://github.com/stalniy/casl) (authorization library) with Angular 2+. There are also a lot of interesting stuff in  documentation - https://stalniy.github.io/casl/ and [related articles on Medium](https://medium.com/@sergiy.stotskiy/latest). 

The library has been around for almost a year, I used it on several projects and believe it's a very good addition to this list.

**P.S.**: 
1. I read guidelines but I need to add a section and library, that's why I think it would be good to do in one PR :) 
2. Direct link to https://devarchy.com/angular returns 502. Works only if I go to https://devarchy.com and then click on Angular